### PR TITLE
nHentai Tag Creation Adjustment

### DIFF
--- a/src/sources/NHentai/NHentai.ts
+++ b/src/sources/NHentai/NHentai.ts
@@ -59,12 +59,7 @@ export class NHentai extends Source {
     // Comma seperate all of the tags and store them in our tag section 
     let tagSections: TagSection[] = [createTagSection({ id: '0', label: 'tag', tags: [] })]
     let tags = $('meta[name="twitter:description"]').attr('content')?.split(",") ?? []
-    for (let i = 0; i < tags.length; i++) {
-      tagSections[0].tags.push(createTag({
-        id: i.toString().trim(),
-        label: tags[i]
-      }))
-    }
+    tagSections[0].tags = tags.map((elem: string) => createTag({id: elem, label: elem}))
 
     // Grab the alternative titles
     let titles = [title]


### PR DESCRIPTION
Manga4Life tag system works. nHentai does not. The only big difference that I can see between the two sources, is how the tags are filled out in the tag-section. 

I've verified that this line adjustment works, and looks fine in a breakpoint for when it's being returned. 
Should we give this a try on nHentai and see if it fixes things? (Matching the Manga4Life method)

(As Manganelo, and other sources have this issue too)