### PR TITLE
Anilist | Properly read and set "Hide From Status List"

### DIFF
--- a/src/Anilist/AlSettings.ts
+++ b/src/Anilist/AlSettings.ts
@@ -9,7 +9,7 @@ export const getDefaultStatus = async (stateManager: SourceStateManager): Promis
 export const getDefaultPrivate = async (stateManager: SourceStateManager): Promise<string[]> => {
     return (await stateManager.retrieve('defaultPrivate') as string[]) ?? ['NEVER']
 }
-export const getDefaultHideFromActivity = async (stateManager: SourceStateManager): Promise<string[]> => {
+export const getDefaultHideFromStatusLists = async (stateManager: SourceStateManager): Promise<string[]> => {
     return (await stateManager.retrieve('defaultHideFromActivity') as string[]) ?? ['NEVER']
 }
 
@@ -83,11 +83,11 @@ export const trackerSettings = (stateManager: SourceStateManager): DUINavigation
                                 ]
                             }),
                             App.createDUISelect({
-                                id: 'defaultHideFromActivity',
-                                label: 'Hide from Activity by Default',
+                                id: 'defaultHideFromStatusLists',
+                                label: 'Hide from Status List by Default',
                                 allowsMultiselect: false,
                                 value: App.createDUIBinding({
-                                    get: () => getDefaultHideFromActivity(stateManager),
+                                    get: () => getDefaultHideFromStatusLists(stateManager),
                                     set: async (newValue) => await stateManager.store('defaultHideFromActivity', newValue)
                                 }),
                                 labelResolver: async (value) => {

--- a/src/Anilist/Anilist.ts
+++ b/src/Anilist/Anilist.ts
@@ -33,7 +33,7 @@ import { AnilistResult } from './models/anilist-result'
 import {
     getDefaultStatus,
     getDefaultPrivate,
-    getDefaultHideFromActivity,
+    getDefaultHideFromStatusLists,
     trackerSettings
 } from './AlSettings'
 
@@ -350,10 +350,10 @@ export class Anilist implements Searchable, MangaProgressProviding {
                                 value: anilistManga.mediaListEntry?.private != undefined ? anilistManga.mediaListEntry.private : ((await getDefaultPrivate(this.stateManager) == 'ADULTONLY' && anilistManga.isAdult || await getDefaultPrivate(this.stateManager) == 'ALWAYS') ? true : false)
                             }),
                             App.createDUISwitch({
-                                id: 'hideFromActivity',
-                                label: 'Hide From Activity',
+                                id: 'hiddenFromStatusLists',
+                                label: 'Hide From Status List',
                                 //@ts-ignore
-                                value: anilistManga.mediaListEntry?.private != undefined ? anilistManga.mediaListEntry.private : ((await getDefaultHideFromActivity(this.stateManager) == 'ADULTONLY' && anilistManga.isAdult || await getDefaultHideFromActivity(this.stateManager) == 'ALWAYS') ? true : false)
+                                value: anilistManga.mediaListEntry?.hiddenFromStatusLists != undefined ? anilistManga.mediaListEntry.hiddenFromStatusLists : ((await getDefaultHideFromStatusLists(this.stateManager) == 'ADULTONLY' && anilistManga.isAdult || await getDefaultHideFromStatusLists(this.stateManager) == 'ALWAYS') ? true : false)
                             })
                         ]
                     }),
@@ -392,7 +392,7 @@ export class Anilist implements Searchable, MangaProgressProviding {
                         progressVolumes: values['progressVolumes'],
                         repeat: values['repeat'],
                         private: values['private'],
-                        hiddenFromStatusLists: values['hideFromActivity'],
+                        hiddenFromStatusLists: values['hiddenFromStatusLists'],
                         score: Number(values['score'])
                     })
                 }


### PR DESCRIPTION
Hello 👋 

This PR fixes a problem where Anilist extension would mistakenly read the value of `private` and set it to `hiddenFromStatusLists` toggle, causing user to accidentally mark an entry private and hide it from their status list by accident.

---

### Reproducible scenario:

1. Track a manga that has `private=true` but `hiddenFromStatusLists=false`.
2. Go into "⚙️ Manage" menu.

#### Expected behavior:

Manga should have  "Private" switch ON, but "Hide from Activity" OFF.

#### Actual behavior:

Manga has  "Private" switch ON and "Hide from Activity" ON.

---

... hence, if user didn't pay attention, they will accidentally set `hiddenFromStatusLists=true` just by pressing "Submit".

Looking at [`MediaListEntry`](https://github.com/Paperback-iOS/extensions/blob/a8fa8571391490ab45d5b9b25ae5dea40db19cfe/src/Anilist/models/anilist-manga.ts#L49-L59) interface, it looks like we should be reading this value from `hiddenFromStatusLists` and not `private` for this value.

I've also updated this toggle to say "Hide From Status Lists" to match Anilist UI. I also update all method calls to reflect this change. However, I decided to keep the storage key as `defaultHideFromActivity` for now, to not break current user's setting, and as I'm not sure which migration scenario the maintainer team would prefer in this scenario.

<img width="242" alt="image" src="https://user-images.githubusercontent.com/105492782/235293620-d2bfdc53-049e-4c27-ae5c-648ef9624a32.png">

I believe this is a good change as this key is used to hide from the "Manga List" page. Meanwhile, private will hide this manga from both manga list and activity list. Hence, if user wants to hide their activity but keep the the manga on their manga list page (while logged in), then they should only set "private" instead.

Please let me know if you have any feedback for this patch. Thank you very much. 🐰 