### PR TITLE
Remove volume check before recording progress

### DIFF
--- a/src/Anilist/Anilist.ts
+++ b/src/Anilist/Anilist.ts
@@ -511,12 +511,8 @@ export class Anilist implements Searchable, MangaProgressProviding {
                 }
 
                 if (anilistManga?.mediaListEntry) {
-                    // If the Anilist volume is higher than progresss, skip
-                    if (anilistManga.mediaListEntry.progressVolumes && anilistManga.mediaListEntry.progressVolumes > Math.floor(readAction.volumeNumber)) {
-                        continue
-                    }
-                    // If the Anilist volume is the same as progress but Anilist chapter is higher or equal, skip
-                    if (anilistManga.mediaListEntry.progress && anilistManga.mediaListEntry.progressVolumes == Math.floor(readAction.volumeNumber) && anilistManga.mediaListEntry.progress >= Math.floor(readAction.chapterNumber)) {
+                    // If the Anilist chapter is higher or equal, skip
+                    if (anilistManga.mediaListEntry.progress && anilistManga.mediaListEntry.progress >= Math.floor(readAction.chapterNumber)) {
                         continue
                     }
                 }

--- a/src/Anilist/Anilist.ts
+++ b/src/Anilist/Anilist.ts
@@ -513,6 +513,7 @@ export class Anilist implements Searchable, MangaProgressProviding {
                 if (anilistManga?.mediaListEntry) {
                     // If the Anilist chapter is higher or equal, skip
                     if (anilistManga.mediaListEntry.progress && anilistManga.mediaListEntry.progress >= Math.floor(readAction.chapterNumber)) {
+                        await actionQueue.discardChapterReadAction(readAction)
                         continue
                     }
                 }


### PR DESCRIPTION
This PR stops tracker from taking the current `progressVolumes` on Anilist into account before making an update to Anilist.

This fixes a scenario where new chapter might not have a volume number, causing the progress update to become no-op.

## Before this change

Given user progress on Anilist is `{ progress: 10, progressVolumes: 2 }`:

| When user reads ... | Update Anilist? | If so, update to? |
|-|-|-|
| Volume 2, Chapter 11 | ✅ |`{ progress: 11, progressVolumes: 2 }` |
| Volume 3, Chapter 11 | ✅ | `{ progress: 11, progressVolumes: 3 }` |
| No Volume, Chapter 11 | ❌ |  |
| No Volume, Chapter 9 | ❌ |  |

## After this change

Same scenario, given user progress on Anilist is `{ progress: 10, progressVolumes: 2 }`:

| When user reads ... | Update Anilist? | If so, update to? |
|-|-|-|
| Volume 2, Chapter 11 | ✅ |`{ progress: 11, progressVolumes: 2 }` |
| Volume 3, Chapter 11 | ✅ | `{ progress: 11, progressVolumes: 3 }` |
| No Volume, Chapter 11 | ✅ | `{ progress: 11 }` (retain the current `progressVolumes` on Anilist) |
| No Volume, Chapter 9 | ❌ |  |

Note that this also adds a missing line to remove the skipped `readAction` from the View Action Queue, as currently any skipped updates would stuck in the View Action Queue.